### PR TITLE
Add support for Shelly Pro3EM using Modbus TCP

### DIFF
--- a/dbus-modbus-client.py
+++ b/dbus-modbus-client.py
@@ -29,6 +29,7 @@ import smappee
 import abb
 import comap
 import victron_em
+import shelly
 
 import logging
 log = logging.getLogger()

--- a/shelly.py
+++ b/shelly.py
@@ -1,0 +1,54 @@
+import logging
+
+import device
+import probe
+from register import *
+
+log = logging.getLogger(__name__)
+
+
+class ShellyEnergyMeter(device.EnergyMeter):
+    # Define mandatory properties so the device gets saved
+    productid = 0xFFFF
+    productname = 'Shelly Energy Meter'
+
+    def __init__(self, spec, modbus, model):
+        super().__init__(spec, modbus, model)
+        # Shelly Modbus devices oddly use input registers for everything
+        self.register_type = device.RegisterType.INPUT
+        self.nr_phases = 3
+
+    def device_init(self):
+        log.info('Initializing Shelly energy meter using connection "%s"', self.connection())
+
+        self.info_regs = [
+            Reg_text(0, 6, '/Serial', little=True),
+            Reg_text(6, 10, '/ProductName', little=True),
+        ]
+
+        self.data_regs = [
+            Reg_f32l(1013, '/Ac/Power', 1, '%.1f W'),
+            Reg_f32l(1020, '/Ac/L1/Voltage', 1, '%.1f V'),
+            Reg_f32l(1022, '/Ac/L1/Current', 1, '%.1f A'),
+            Reg_f32l(1024, '/Ac/L1/Power', 1, '%.1f W'),
+            Reg_f32l(1040, '/Ac/L2/Voltage', 1, '%.1f V'),
+            Reg_f32l(1042, '/Ac/L2/Current', 1, '%.1f A'),
+            Reg_f32l(1044, '/Ac/L2/Power', 1, '%.1f W'),
+            Reg_f32l(1060, '/Ac/L3/Voltage', 1, '%.1f V'),
+            Reg_f32l(1062, '/Ac/L3/Current', 1, '%.1f A'),
+            Reg_f32l(1064, '/Ac/L3/Power', 1, '%.1f W'),
+        ]
+        
+    def get_ident(self):
+        return 'shelly_{}'.format(self.info['/Serial'])
+
+
+class ShellyModelRegister(probe.ModelRegister):
+    def __init__(self, **args):
+        super().__init__(None, [], **args)
+
+    def probe(self, spec, modbus, timeout=None):
+        return ShellyEnergyMeter(spec, modbus, 'SPEM-003CE')
+
+
+probe.add_handler(ShellyModelRegister(methods=['tcp'], units=[1]))

--- a/shelly.py
+++ b/shelly.py
@@ -14,6 +14,8 @@ class ShellyEnergyMeter(device.CustomName, device.EnergyMeter):
 
     def __init__(self, spec, modbus, model):
         super().__init__(spec, modbus, model)
+        # Increase default timeout
+        self.min_timeout = 0.5
         # Shelly Modbus devices oddly use input registers for everything
         self.register_type = device.RegisterType.INPUT
         self.nr_phases = 3

--- a/shelly.py
+++ b/shelly.py
@@ -27,13 +27,21 @@ class ShellyEnergyMeter(device.EnergyMeter):
         ]
 
         self.data_regs = [
+            Reg_f32l(1162, '/Ac/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1164, '/Ac/Energy/Reverse', 1000, '%.1f kWh'),
             Reg_f32l(1013, '/Ac/Power', 1, '%.1f W'),
+            Reg_f32l(1182, '/Ac/L1/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1184, '/Ac/L1/Energy/Reverse', 1000, '%.1f kWh'),
             Reg_f32l(1020, '/Ac/L1/Voltage', 1, '%.1f V'),
             Reg_f32l(1022, '/Ac/L1/Current', 1, '%.1f A'),
             Reg_f32l(1024, '/Ac/L1/Power', 1, '%.1f W'),
+            Reg_f32l(1202, '/Ac/L2/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1204, '/Ac/L2/Energy/Reverse', 1000, '%.1f kWh'),
             Reg_f32l(1040, '/Ac/L2/Voltage', 1, '%.1f V'),
             Reg_f32l(1042, '/Ac/L2/Current', 1, '%.1f A'),
             Reg_f32l(1044, '/Ac/L2/Power', 1, '%.1f W'),
+            Reg_f32l(1222, '/Ac/L3/Energy/Forward', 1000, '%.1f kWh'),
+            Reg_f32l(1224, '/Ac/L3/Energy/Reverse', 1000, '%.1f kWh'),
             Reg_f32l(1060, '/Ac/L3/Voltage', 1, '%.1f V'),
             Reg_f32l(1062, '/Ac/L3/Current', 1, '%.1f A'),
             Reg_f32l(1064, '/Ac/L3/Power', 1, '%.1f W'),

--- a/shelly.py
+++ b/shelly.py
@@ -7,7 +7,7 @@ from register import *
 log = logging.getLogger(__name__)
 
 
-class ShellyEnergyMeter(device.EnergyMeter):
+class ShellyEnergyMeter(device.CustomName, device.EnergyMeter):
     # Define mandatory properties so the device gets saved
     productid = 0xFFFF
     productname = 'Shelly Energy Meter'


### PR DESCRIPTION
The https://github.com/victronenergy/dbus-shelly implementation has several shortcomings, among others:

* it only updates ever so often (whenever the device itself broadcasts a `NotifyStatus` to all connected clients)
* it's flaky, sometimes device information is missing (https://github.com/victronenergy/dbus-shelly/issues/9)
* all phases are for some reason not shown in the remote console or VRM (https://github.com/victronenergy/dbus-shelly/issues/4)

I realized that there is already great boilerplate and plumbing available for Modbus devices, so why not use that since the new Shelly Pro3EM supports Modbus TCP.

Compared to `dbus-shelly`, this:
* updates every second (this is as fast as the Shelly internally updates itself, reading register more frequently won't produce more granular readings)
* device information is registered correctly every time
* device shows up in VRM
* readings for all phases are shown on the main page

Some caveats:
* Shelly Pro3EM uses input registers for everything, not holding registers
* Only the `triphase` profile is supported
* Firmware version, device name, generic information, none of that is available via Modbus (at least for now)
* ~Energy readings (forward, reverse) are not available from the device itself~
* Device probing is very rudimentary and may need further improvements
* ~Device name gets `BEU` added to the end for some unknown reason. Might be that we need a custom method for reading strings from these devices.~ This is apparently correct, see e.g. https://device.report/allterco-robotics/spem-003cebeu
* Error codes/alarms not yet supported

Would be great to get some feedback on this!

Screenshots:
![2023-10-16_22-39](https://github.com/victronenergy/dbus-modbus-client/assets/1106133/828431f4-a18c-4eb1-a7b7-7121c301dbe9)
![2023-10-16_22-39_1](https://github.com/victronenergy/dbus-modbus-client/assets/1106133/a4b34f45-bb9b-4767-9c56-eb5d95c12f88)
![2023-10-16_22-42](https://github.com/victronenergy/dbus-modbus-client/assets/1106133/4fdaa47e-4dc6-478c-893a-7fd58741a379)
![2023-10-16_22-48_1](https://github.com/victronenergy/dbus-modbus-client/assets/1106133/29003e28-313f-4703-96eb-330c8774c23e)
