### PR TITLE
Generic and configurable modbus meter device support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ FILES =									\
 	victron_regs.py							\
 	vreglink.py							\
 	watchdog.py							\
+	generic_modbus_meter.py						\
 
 VELIB =									\
 	settingsdevice.py						\

--- a/dbus-modbus-client.py
+++ b/dbus-modbus-client.py
@@ -29,6 +29,7 @@ import smappee
 import abb
 import comap
 import victron_em
+import generic_modbus_meter
 
 import logging
 log = logging.getLogger()

--- a/generic_modbus_meter.py
+++ b/generic_modbus_meter.py
@@ -1,0 +1,82 @@
+import struct
+import device
+import probe
+import logging
+import json
+import utils
+
+import register
+
+class GenericMeterRTU(device.CustomName, device.EnergyMeter):
+    """ Generic Meter """
+    def __init__(self, config, spec, modbus, model):
+        super().__init__(spec, modbus, model)
+        self.config = config
+        self.productid =   config.get('product_id', 0)
+        self.min_timeout = config.get('timeout', 1.0)
+        self.productname = config.get('product_name', "UNAMED PRODUCT");
+
+    def init(self, dbus, enable=True):
+        super().init(dbus, enable)
+        self.dbus.add_path ('/Serial', self.config.get('serial', "UNKNOWN"))
+        self.dbus.add_path ('/FirmwareVersion', self.config.get('version', "UNKNOWN"))
+
+    def set_config(self, config):
+        self.config = config
+        return self
+
+    def device_init(self):
+        self.info_regs = []
+
+        self.data_regs = []
+        rjs = self.config['data_regs']
+        for rj in rjs:
+            self.data_regs.append(register.register_from_object(rj))
+
+    def get_ident(self):
+        return self.config['model']
+
+class MatchWithConfig:
+    def __init__(self, config, **args):
+        self.timeout = args.get('timeout', 1)
+        self.methods = args.get('methods', [])
+        self.units = args.get('units', [])
+        self.rates = args.get('rates', [])
+        self.config = config
+
+    def probe(self, spec, modbus, timeout=2):
+        r = self.config['probe']['reg']
+        reg = register.register_from_object(r)
+
+        rr = None
+        with modbus, utils.timeout(modbus, timeout or self.timeout):
+            if not modbus.connect():
+                raise Exception('connection error')
+
+            if(r['type'] == 'input_register'):
+                rr = modbus.read_input_registers(reg.base, reg.count, unit=spec.unit)
+            elif(r['type'] == 'holding_register'):
+                rr = modbus.read_holding_registers(reg.base, reg.count, unit=spec.unit)
+
+        if rr == None or rr.isError():
+            log.debug('%s: %s', modbus, rr)
+            return None
+
+        reg.decode(rr.registers)
+        if(self.config['probe']['match'] == reg.value):
+            return GenericMeterRTU(self.config, spec, modbus, self.config['model']).set_config(self.config)
+
+        return None
+
+try:
+    with open(f"/data/etc/generic_rtu_meter.json") as user_file:
+        file_contents = user_file.read()
+        configs = json.loads(file_contents)
+        for config in configs:
+            probe.add_handler(MatchWithConfig(config,
+                                              methods=['rtu'],
+                                              units=[1],
+                                              timeout=5.0))
+                                              ##rates=[9600]))
+except:
+    raise Exception('error reading config file')

--- a/generic_rtu_meter.example.json
+++ b/generic_rtu_meter.example.json
@@ -1,0 +1,38 @@
+[
+  {
+    "product_id": 0,
+    "product_name": "TestProduct",
+    "model": "TestName",
+    "version": "0.1",
+    "serial": "12345678",
+    "probe": {
+      "reg": {
+        "base": 0,
+        "type": "holding_register",
+        "data_type": "f32b"
+      },
+      "match": 9600.0
+    },
+    "data_regs": [
+      {
+	"type": "input_register",
+	"data_type": "f32b",
+	"name": "/Ac/Power",
+	"base": 10,
+	"scale": 1,
+	"text": "%.1f W"
+      },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/Frequency",      "base": 54,    "scale": 1, "text": "%.1f Hz" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/Energy/Forward", "base": 256,   "scale": 1, "text": "%.1f kWh" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/L1/Voltage",     "base": 0,     "scale": 1, "text": "%.1f V" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/L2/Voltage",     "base": 2,     "scale": 1, "text": "%.1f V" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/L3/Voltage",     "base": 4,     "scale": 1, "text": "%.1f V" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/L1/Current",     "base": 8,     "scale": 1, "text": "%.1f A" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/L2/Current",     "base": 10,     "scale": 1, "text": "%.1f A" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/L3/Current",     "base": 12,     "scale": 1, "text": "%.1f A" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/L1/Power",       "base": 16,    "scale": 1, "text": "%.1f W" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/L2/Power",       "base": 18,    "scale": 1, "text": "%.1f W" },
+      { "type": "input_register", "data_type": "f32b", "name": "/Ac/L3/Power",       "base": 20,    "scale": 1, "text": "%.1f W" }
+    ]
+  }
+]

--- a/register.py
+++ b/register.py
@@ -158,3 +158,65 @@ class Reg_map:
 
 class Reg_mapu16(Reg_map, Reg_u16):
     pass
+
+
+def register_from_object(obj):
+    try:
+        ref = None
+        if obj['data_type'] == 's16':
+            ref = Reg_s16
+        elif obj['data_type'] == 'u16 ':
+            ref = Reg_u16
+        elif obj['data_type'] == 's32b':
+            ref = Reg_s32b
+        elif obj['data_type'] == 'u32b':
+            ref = Reg_u32b
+        elif obj['data_type'] == 'u64b':
+            ref = Reg_u64b
+        elif obj['data_type'] == 's32l':
+            ref = Reg_s32l
+        elif obj['data_type'] == 'u32l':
+            ref = Reg_u32l
+        elif obj['data_type'] == 'f32l':
+            ref = Reg_f32l
+        elif obj['data_type'] == 'f32b':
+            ref = Reg_f32b
+        elif obj['data_type'] == 'e16':
+            ref = Reg_e16
+        elif obj['data_type'] == 'text':
+            ref = Reg_text
+        elif obj['data_type'] == 'mapu16':
+            ref = Reg_mapu16
+
+
+        base =  obj.get('base', None)
+        name  = obj.get('name', None)
+        text  = obj.get('text', None)
+        write = obj.get('write', False)
+        extra = obj.get('extra', {})
+        reg_type  = obj.get('type', 'holding_register')
+
+        ret = None
+        if issubclass(ref, Reg_num):
+            scale =   obj.get('scale', 1)
+            invalid = obj.get('invalid', [])
+            ret = ref(base, name, scale, text, write, invalid, *extra)
+        elif issubclass(ref, Reg_e16):
+            enum = obj.get('enum', {})
+            ret = ref(base, name, enum, *extra)
+        elif issubclass(ref, Reg_text):
+            count = obj.get('count', 1)
+            little = obj.get('little', False)
+            encoding = obj.get('encoding', None)
+            ret = ref(base, name, count, name, little, encoding, *extra)
+        elif issubclass(ref, Reg_map):
+            args = obj.get('extra', {})
+            tab = obj.get('tab', {})
+            ret = ref(base, name, tab, args, *extra)
+
+        if reg_type == 'input_register':
+            ret.as_input_register();
+
+        return ret
+    except:
+        return None

--- a/register.py
+++ b/register.py
@@ -17,6 +17,7 @@ class Reg:
         self.time = 0
         self.max_age = max_age
         self.text = text
+        self.base_register_type = 4
 
     def __eq__(self, other):
         if isinstance(other, type(self)):
@@ -40,6 +41,10 @@ class Reg:
         if callable(self.text):
             return self.text(self.value)
         return str(self.value)
+
+    def as_input_register(self):
+        self.base_register_type = 3
+        return self
 
     def isvalid(self):
         return self.value is not None

--- a/register.py
+++ b/register.py
@@ -106,6 +106,11 @@ class Reg_f32l(Reg_num):
     count = 2
     rtype = float
 
+class Reg_f32b(Reg_num):
+    coding = ('>f', '>2H')
+    count = 2
+    rtype = float
+
 class Reg_e16(Reg, int):
     def __init__(self, base, name, enum, **kwargs):
         super().__init__(base, 1, name, **kwargs)


### PR DESCRIPTION
More affordable meter devices usually are not capable to be identified through inspection of it modbus registers, due to lack of specific registers that identify the device, and for that reason are impossible to be supported.
Any solution implies that the user would somehow hand specify the device.

This pull request suggests a solution to this problem by introducing a more configurable meter device, in which the end user/installer can provide the missing information, such as the registers for the paths, etc.

Personally I would love to support this device through the GUI, however and so far I lack the proper knowledge to make such implementation.
The solution for configuration was in the form of a json file, also included in the last commit.

Looking forward for your comments and suggestions on how to properly add such functionality to the project.
