### PR TITLE
Add missing RegisterTypes

### DIFF
--- a/register.py
+++ b/register.py
@@ -89,10 +89,6 @@ class Reg_u32b(Reg_num):
     coding = ('>I', '>2H')
     count = 2
 
-class Reg_u64b(Reg_num):
-    coding = ('>Q', '>4H')
-    count = 4
-
 class Reg_s32l(Reg_num):
     coding = ('<i', '<2H')
     count = 2
@@ -100,6 +96,27 @@ class Reg_s32l(Reg_num):
 class Reg_u32l(Reg_num):
     coding = ('<I', '<2H')
     count = 2
+
+class Reg_s64b(Reg_num):
+    coding = ('>q', '>4H')
+    count = 4
+
+class Reg_u64b(Reg_num):
+    coding = ('>Q', '>4H')
+    count = 4
+
+class Reg_s64l(Reg_num):
+    coding = ('<q', '<4H')
+    count = 4
+
+class Reg_u64l(Reg_num):
+    coding = ('<Q', '<4H')
+    count = 4
+
+class Reg_f32b(Reg_num):
+    coding = ('>f', '>2H')
+    count = 2
+    rtype = float
 
 class Reg_f32l(Reg_num):
     coding = ('<f', '<2H')


### PR DESCRIPTION
Reg_s64b
Reg_s64l
Reg_u64l
Reg_f32b

So that everyone uses the same classes in delivered scripts and externally provided ones