### PR TITLE
Add inherited access to the newly created RegList while dividing RegList

### DIFF
--- a/device.py
+++ b/device.py
@@ -44,7 +44,7 @@ def pack_list(rr, access, hole_max, barrier):
         if nr > 125 or (r.base - end) > hole_max or \
            contains_any(end, r.base, barrier):
             regs.append(rg)
-            rg = RegList()
+            rg = RegList(access)
 
         rg.append(r)
 


### PR DESCRIPTION
I encountered this problem while writing a driver for a 3rd-party smart meter. If you have several registers with 'input' access and their addresses contain a "hole", the access is assigned only to the first created RegList, while the others receive None, which later defaults to 'holding'.