### PR TITLE
Add support for ET112 Energy Meters via TCP

### DIFF
--- a/carlo_gavazzi.py
+++ b/carlo_gavazzi.py
@@ -144,12 +144,12 @@ class ET112_Meter(device.CustomName, device.EnergyMeter):
             Reg_s16( 0x000F, '/Ac/Frequency',         10, '%.1f Hz'),
             Reg_s16( 0x000E, '/Ac/PowerFactor',     1000, '%.2f'),
             Reg_s32l(0x0010, '/Ac/Energy/Forward',    10, '%.1f kWh'),
-            Reg_s32l(0x0020, '/Ac/Energy/Reverse',    10, '%.1f kWh'),
+            Reg_s32l(0x0020, '/Ac/Energy/Reverse',    -10, '%.1f kWh'),
             Reg_s32l(0x0000, '/Ac/L1/Voltage',        10, '%.1f V'),
             Reg_s32l(0x0002, '/Ac/L1/Current',      1000, '%.1f A'),
             Reg_s32l(0x0004, '/Ac/L1/Power',          10, '%.1f W'),
             Reg_s32l(0x0010, '/Ac/L1/Energy/Forward', 10, '%.1f kWh'),
-            Reg_s32l(0x0020, '/Ac/L1/Energy/Reverse', 10, '%.1f kWh'),
+            Reg_s32l(0x0020, '/Ac/L1/Energy/Reverse', -10, '%.1f kWh'),
         ]
 
         self.data_regs = regs

--- a/carlo_gavazzi.py
+++ b/carlo_gavazzi.py
@@ -126,6 +126,17 @@ class ET112_Meter(device.CustomName, device.EnergyMeter):
             Reg_text_et112(0x5000, 7, '/Serial'),
         ]
 
+        # make sure measurement mode is set to 1 (B) for bidirectional
+        appreg = Reg_u16(0x1103)
+        if self.read_register(appreg) != 1:
+            self.write_register(appreg, 1)
+
+            # read back the value in case the setting is not accepted
+            # for some reason
+            if self.read_register(appreg) != 1:
+                self.log.error('%s: failed to set measurement to bidirectional', self)
+                return
+
         self.read_info()
 
         regs = [


### PR DESCRIPTION
This PR adds support for the ET112 energy meter but over ModbusTCP.

My ET112 is mounted quite a long way from the rest of my Victron equipment (I think this is a common issue). It's too far for RS485 directly and I didn't want to buy 2x RS485<>WiFi bridges. Instead, I've used one (a RPi Zero W and RS485 HAT I had lying around running [mbusd](https://github.com/3cky/mbusd)) and written this modification so that dbus-modbus-client will recognise the ET112 as well as the EM40.

In the end, this is a small change as the ET112 is quite simple, but I think it will help a fair few people.

<img width="568" height="265" alt="image" src="https://github.com/user-attachments/assets/fba26968-5974-49df-8b85-e98a27f43496" />
