### PR TITLE
Add support for Datakom genset controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ FILES +=								\
 	carlo_gavazzi.py						\
 	comap.py							\
 	cre.py								\
+	datakom.py							\
 	deif.py								\
 	dse.py								\
 	ev_charger.py							\

--- a/datakom.py
+++ b/datakom.py
@@ -1,0 +1,169 @@
+import struct
+import device
+import probe
+from register import Reg, Reg_u16, Reg_u32l, Reg_mapu16
+
+class Reg_Datakom_ident(Reg, str):
+    def __init__(self):
+        super().__init__(10609, 1)
+
+    def decode(self, values):
+        return self.update(''.join(f'{value:04X}' for value in values))
+
+class Reg_Datakom_serial(Reg, str):
+    def __init__(self):
+        super().__init__(11687, 6, '/Serial')
+
+    def decode(self, values):
+        return self.update(''.join(f'{(value >> 8) | ((value & 0xFF) << 8):04X}' for value in values))
+
+class Reg_Datakom_fw(Reg, str):
+    def __init__(self):
+        super().__init__(10611, 1, '/FirmwareVersion')
+
+    def decode(self, values):
+        return self.update('.'.join(str(values[0])))
+
+class Datakom_Tank(device.CustomName, device.Tank, device.SubDevice):
+    raw_value_min = 0
+    raw_value_max = 100
+    raw_unit = '%'
+
+    def device_init(self):
+        self.data_regs = [
+            Reg_u16(10363, '/RawValue', 10, '%.0f %%'),
+        ]
+
+class Datakom_Generator(device.CustomName, device.Genset):
+    vendor_id = 'datakom'
+    vendor_name = 'Datakom'
+    productid = 0xB04B
+    productname = 'Datakom genset controller'
+    min_timeout = 0.5
+    reg_hole_max = 0
+
+    def device_init(self):
+        self.info_regs = [
+            Reg_Datakom_serial(),
+            Reg_Datakom_fw(),
+            Reg_mapu16(321, '/NrOfPhases', {
+                0: 2, 1: 2, # Split phase
+                2: 3, 3: 3, 4: 3, 5: 3, 6: 3, # 3 phase
+                7: 1 # single phase 
+            })
+        ]
+
+        self.data_regs = [
+            Reg_u32l(10628,   '/Ac/Energy/Forward', 10, '%.0f kWh'),
+            Reg_u32l(10294,   '/Ac/Power',          0.01, '%.0f W'),
+            Reg_u16(10339,    '/Ac/Frequency',      100, '%.1f Hz'),
+
+            Reg_u32l(10270,   '/Ac/L1/Current',     10, '%.0f A'),
+            Reg_u32l(10286,   '/Ac/L1/Power',       0.01, '%.0f W'),
+            Reg_u32l(10246,   '/Ac/L1/Voltage',     10, '%.0f V'),
+            
+            Reg_u32l(10272,   '/Ac/L2/Current',     10, '%.0f A'),
+            Reg_u32l(10288,   '/Ac/L2/Power',       0.01, '%.0f W'),
+            Reg_u32l(10248,   '/Ac/L2/Voltage',     10, '%.0f V'),
+
+            Reg_u32l(10274,   '/Ac/L3/Current',     10, '%.0f A'),
+            Reg_u32l(10290,   '/Ac/L3/Power',       0.01, '%.0f W'),
+            Reg_u32l(10250,   '/Ac/L3/Voltage',     10, '%.0f V'),
+
+            Reg_mapu16(10605, '/RemoteStartModeEnabled', {
+                1: 0, # STOP mode
+                2: 1, # RUN/MANUAL mode
+                4: 1, # AUTO mode
+                8: 0  # TEST mode
+            }),
+
+            Reg_u16(10341,     '/StarterVoltage', 100, '%.1f V'),
+            Reg_mapu16(10604,  '/StatusCode', {
+                0: 0, # genset at rest
+                1: 1, # wait before fuel
+                2: 1, # engine preheat
+                3: 1, # wait oil flash off
+                4: 1, # crank rest
+                5: 1, # cranking
+                6: 8, # engine run idle speed
+                7: 8, # engine heating
+                8: 8, # running off load
+                9: 8, # synchronizing to mains
+                10: 8, # load transfer to genset
+                11: 8, # gen cb activation
+                12: 8, # genset cb timer
+                13: 8, # master genset on load
+                14: 8, # peak lopping
+                15: 8, # power exporting
+                16: 8, # slave genset on load
+                17: 8, # synchronizing back to mains
+                18: 8, # load transfer to mains
+                19: 8, # mains cb activation
+                20: 8, # mains cb timer
+                21: 9, # stop with cooldown
+                22: 9, # cooling down
+                23: 9, # engine stop idle speed
+                24: 9, # immediate stop
+                25: 9 # engine stopping
+            }),
+            
+            Reg_u16(10362,     '/Engine/CoolantTemperature', 10, '%.1f C'),
+            Reg_u16(10361,     '/Engine/OilPressure',        0.1, '%.0f kPa'),
+            Reg_u16(10364,     '/Engine/OilTemperature',     10, '%.1f C', invalid=0x7FFF),
+            Reg_u32l(10622,    '/Engine/OperatingHours',     1/36, '%.1f s'),
+            Reg_u16(10376,     '/Engine/Speed',              1, '%.0f RPM'),
+            Reg_u16(10616,     '/Engine/Starts',             1, '%.0f'),
+        ]
+
+        if self.read_register(Reg_u16(10363)) is not None:
+            self.subdevices = [
+                Datakom_Tank(self, 0),
+            ]
+
+    def device_init_late(self):
+        super().device_init_late()
+
+        self.dbus.add_path(
+            '/Start',
+            0,
+            writeable=True,
+            onchangecallback=self._start_genset
+        )
+
+        self.dbus.add_path(
+            '/EnableRemoteStartMode',
+            0,
+            writeable=True,
+            onchangecallback=self._set_remote_start_mode
+        )
+
+    def _start_genset(self, _, value):
+        if value:
+            self.write_modbus(8193, [18])
+        else:
+            self.write_modbus(8193, [4])
+        return True
+
+    def _set_remote_start_mode(self, _, value):
+        return True
+
+models = {
+    'D300': { # D-300
+        'model': 'D-300',
+        'handler': Datakom_Generator,
+    },
+    'D500': { # D-500
+        'model': 'D-500',
+        'handler': Datakom_Generator,
+    },
+    'D545': { # D-545
+        'model': 'D-545',
+        'handler': Datakom_Generator,
+    },
+    'D700': { # D-700
+        'model': 'D-700',
+        'handler': Datakom_Generator,
+    }
+}
+probe.add_handler(probe.ModelRegister(Reg_Datakom_ident(), models,
+                                      methods=['tcp'], units=[1]))

--- a/datakom.py
+++ b/datakom.py
@@ -8,7 +8,7 @@ class Reg_Datakom_fw(Reg, str):
         super().__init__(10611, 1, '/FirmwareVersion')
 
     def decode(self, values):
-        return self.update('.'.join(str(values[0])))
+        return self.update('.'.join(str(x) for x in divmod(values[0], 16)))
 
 class Datakom_Tank(device.CustomName, device.Tank, device.SubDevice):
     raw_value_min = 0

--- a/datakom.py
+++ b/datakom.py
@@ -116,19 +116,9 @@ class Datakom_Generator(device.CustomName, device.Genset):
             onchangecallback=self._start_genset
         )
 
-        self.dbus.add_path(
-            '/EnableRemoteStartMode',
-            0,
-            writeable=True,
-            onchangecallback=self._set_remote_start_mode
-        )
-
     def _start_genset(self, _, value):
         v = 18 if value else 4
         self.write_modbus(8193, [v])
-        return True
-
-    def _set_remote_start_mode(self, _, value):
         return True
 
 models = {

--- a/datakom.py
+++ b/datakom.py
@@ -1,0 +1,154 @@
+import struct
+import device
+import probe
+from register import Reg, Reg_u16, Reg_u32l, Reg_mapu16, Reg_hexstr
+
+class Reg_Datakom_fw(Reg, str):
+    def __init__(self):
+        super().__init__(10611, 1, '/FirmwareVersion')
+
+    def decode(self, values):
+        return self.update('.'.join(str(values[0])))
+
+class Datakom_Tank(device.CustomName, device.Tank, device.SubDevice):
+    raw_value_min = 0
+    raw_value_max = 100
+    raw_unit = '%'
+
+    def device_init(self):
+        self.data_regs = [
+            Reg_u16(10363, '/RawValue', 10, '%.0f %%'),
+        ]
+
+class Datakom_Generator(device.CustomName, device.Genset):
+    vendor_id = 'datakom'
+    vendor_name = 'Datakom'
+    productid = 0xB04B
+    productname = 'Datakom genset controller'
+    min_timeout = 0.5
+    reg_hole_max = 0
+
+    def device_init(self):
+        self.info_regs = [
+            Reg_hexstr(11687, 6, '/Serial', little=True, upper=True),
+            Reg_Datakom_fw(),
+            Reg_mapu16(321, '/NrOfPhases', {
+                0: 2, 1: 2,                   # split phase
+                2: 3, 3: 3, 4: 3, 5: 3, 6: 3, # 3 phase
+                7: 1,                         # single phase
+            })
+        ]
+
+        self.data_regs = [
+            Reg_u32l(10628,   '/Ac/Energy/Forward', 10, '%.0f kWh'),
+            Reg_u32l(10294,   '/Ac/Power',          0.01, '%.0f W'),
+            Reg_u16(10339,    '/Ac/Frequency',      100, '%.1f Hz'),
+
+            Reg_u32l(10270,   '/Ac/L1/Current',     10, '%.0f A'),
+            Reg_u32l(10286,   '/Ac/L1/Power',       0.01, '%.0f W'),
+            Reg_u32l(10246,   '/Ac/L1/Voltage',     10, '%.0f V'),
+
+            Reg_u32l(10272,   '/Ac/L2/Current',     10, '%.0f A'),
+            Reg_u32l(10288,   '/Ac/L2/Power',       0.01, '%.0f W'),
+            Reg_u32l(10248,   '/Ac/L2/Voltage',     10, '%.0f V'),
+
+            Reg_u32l(10274,   '/Ac/L3/Current',     10, '%.0f A'),
+            Reg_u32l(10290,   '/Ac/L3/Power',       0.01, '%.0f W'),
+            Reg_u32l(10250,   '/Ac/L3/Voltage',     10, '%.0f V'),
+
+            Reg_mapu16(10605, '/RemoteStartModeEnabled', {
+                1: 0, # STOP mode
+                2: 1, # RUN/MANUAL mode
+                4: 1, # AUTO mode
+                8: 0, # TEST mode
+            }),
+
+            Reg_u16(10341,     '/StarterVoltage', 100, '%.1f V'),
+            Reg_mapu16(10604,  '/StatusCode', {
+                0:  0,          # genset at rest
+                1:  1,          # wait before fuel
+                2:  1,          # engine preheat
+                3:  1,          # wait oil flash off
+                4:  1,          # crank rest
+                5:  1,          # cranking
+                6:  8,          # engine run idle speed
+                7:  8,          # engine heating
+                8:  8,          # running off load
+                9:  8,          # synchronizing to mains
+                10: 8,          # load transfer to genset
+                11: 8,          # gen cb activation
+                12: 8,          # genset cb timer
+                13: 8,          # master genset on load
+                14: 8,          # peak lopping
+                15: 8,          # power exporting
+                16: 8,          # slave genset on load
+                17: 8,          # synchronizing back to mains
+                18: 8,          # load transfer to mains
+                19: 8,          # mains cb activation
+                20: 8,          # mains cb timer
+                21: 9,          # stop with cooldown
+                22: 9,          # cooling down
+                23: 9,          # engine stop idle speed
+                24: 9,          # immediate stop
+                25: 9,          # engine stopping
+            }),
+
+            Reg_u16(10362,     '/Engine/CoolantTemperature', 10, '%.1f C'),
+            Reg_u16(10361,     '/Engine/OilPressure',        0.1, '%.0f kPa'),
+            Reg_u16(10364,     '/Engine/OilTemperature',     10, '%.1f C', invalid=0x7FFF),
+            Reg_u32l(10622,    '/Engine/OperatingHours',     1/36, '%.1f s'),
+            Reg_u16(10376,     '/Engine/Speed',              1, '%.0f RPM'),
+            Reg_u16(10616,     '/Engine/Starts',             1, '%.0f'),
+        ]
+
+        if self.read_register(Reg_u16(10363)) is not None:
+            self.subdevices = [
+                Datakom_Tank(self, 0),
+            ]
+
+    def device_init_late(self):
+        super().device_init_late()
+
+        self.dbus.add_path(
+            '/Start',
+            0,
+            writeable=True,
+            onchangecallback=self._start_genset
+        )
+
+        self.dbus.add_path(
+            '/EnableRemoteStartMode',
+            0,
+            writeable=True,
+            onchangecallback=self._set_remote_start_mode
+        )
+
+    def _start_genset(self, _, value):
+        v = 18 if value else 4
+        self.write_modbus(8193, [v])
+        return True
+
+    def _set_remote_start_mode(self, _, value):
+        return True
+
+models = {
+    0xd300: {
+        'model': 'D-300',
+        'handler': Datakom_Generator,
+    },
+    0xd500: {
+        'model': 'D-500',
+        'handler': Datakom_Generator,
+    },
+    0xd545: {
+        'model': 'D-545',
+        'handler': Datakom_Generator,
+    },
+    0xd700: {
+        'model': 'D-700',
+        'handler': Datakom_Generator,
+    },
+}
+
+probe.add_handler(probe.ModelRegister(Reg_u16(10609), models,
+                                      methods=['tcp'], units=[1]))

--- a/dbus-modbus-client.py
+++ b/dbus-modbus-client.py
@@ -35,6 +35,7 @@ import ev_charger
 import smappee
 import victron_em
 import victron_p1link
+import datakom
 
 import logging
 log = logging.getLogger()

--- a/dbus-modbus-client.py
+++ b/dbus-modbus-client.py
@@ -29,6 +29,7 @@ import abb
 import carlo_gavazzi
 import comap
 import cre
+import datakom
 import deif
 import dse
 import ev_charger

--- a/register.py
+++ b/register.py
@@ -162,6 +162,17 @@ class Reg_text(Reg, str):
         return struct.unpack(self.pfmt,
             self.value.encode(self.encoding).ljust(2 * self.count, b'\0'))
 
+class Reg_hexstr(Reg, str):
+    def __init__(self, base, count, name=None, little=False, upper=False, **kwargs):
+        super().__init__(base, count, name, **kwargs)
+        self.pfmt = '%c%dH' % (['>', '<'][little], count)
+
+    def decode(self, values):
+        newval = struct.pack(self.pfmt, *values).hex()
+        if self.upper:
+            newval = newval.upper()
+        return self.update(newval)
+
 class Reg_map:
     def __init__(self, base, name, tab, *args, **kwargs):
         super().__init__(base, name, *args, **kwargs)


### PR DESCRIPTION
This PR adds ModbusTCP support for the Datakom genset controller family.

The implementation was tested successfully on a [Grupel G545](https://grupel.eu/en/grupel-controllers-the-brains-that-respond-to-market-needs/), which is an OEM‑branded version of the Datakom D500, and to the best of our knowledge this is the only OEM Datakom manufactures. Because the D500 belongs to the Datakom D‑500 family, this PR should in principle support all controllers in that family.

The code also includes identification logic for the D‑300 and D‑700 families. These models were not available for testing, so compatibility with them cannot be guaranteed.

Below are screenshots from a Cerbo GX running Venus OS 3.72, showing the genset pages populated using this driver.

<img width="1240" height="798" alt="image" src="https://github.com/user-attachments/assets/b1c1cb7d-2f63-41a6-978f-a2eae8aea2dd" />
<img width="1253" height="805" alt="image" src="https://github.com/user-attachments/assets/7fdd0950-13d1-4284-a42d-8d19d4ba2b2c" />
<img width="1240" height="807" alt="image" src="https://github.com/user-attachments/assets/72ac1831-2b92-486d-a147-05cd435ae38f" />

### Note regarding connection to the different controllers:

<img width="833" height="299" alt="image" src="https://github.com/user-attachments/assets/e3412386-3349-4b3e-ad9b-1b727548feb6" />


### Note regarding galvanic isolation:

There are some old models with standard modbus rtu terminal. Grupel 545 controller also has mobus rtu terminal on main board as standard feature. It is non isolated for all these models.

The new model of Datakom controllers support modbus rtu and modbus tcp communication with optional plugin modules.

The optional plugin rs-485 module is compatible with D100/200/300/500lite/500/700 MK2-MK3 controllers and it is isolated.
[plug-in_rs-485_module_INSTE](https://www.datakom.com.tr/upload/files/plug-in_rs-485_module_INSTE.pdf)

The optional plugin ethernet module is also compatible with D100/200/300/500lite/500/700 MK2-MK3 controllers.
[plug-in_ETH_module_INSTE](https://www.datakom.com.tr/upload/files/plug-in_ETH_module_INSTE.pdf)

The optional plugin comm module is suitable for D500/700 MK2-MK3 controllers only and the same module has rs-485 & ethernet port. The rs-485 terminal on plugin comm module is non isolated.
[500mk2_plug-in_comm_module_INSTE](https://www.datakom.com.tr/upload/files/500mk2_plug-in_comm_module_INSTE.pdf)